### PR TITLE
1.7 obs spec modifications to build with version 0.5.1 of omemo

### DIFF
--- a/rpm/qxmpp.spec
+++ b/rpm/qxmpp.spec
@@ -11,7 +11,10 @@ Source:     %{name}-%{version}.tar.gz
 URL:        https://github.com/ron282/qxmpp.git
 License:    LGPLv2+
 BuildRequires: cmake qca-devel omemo-c-devel qt5-qttest-devel qt5-qtnetwork-devel qt5-qtxml-devel
-Requires:   qca omemo-c
+
+BuildRequires: pkgconfig(libomemo-c)
+
+Requires:      pkgconfig(libomemo-c)
 
 %description
 QXmpp is a cross-platform C++ XMPP client and server library. It is written in C++ and uses Qt framework.

--- a/rpm/qxmpp.spec
+++ b/rpm/qxmpp.spec
@@ -10,7 +10,7 @@ Group:      Qt/Qt
 Source:     %{name}-%{version}.tar.gz
 URL:        https://github.com/ron282/qxmpp.git
 License:    LGPLv2+
-BuildRequires: cmake qca-devel omemo-c-devel qt5-qttest-devel qt5-qtnetwork-devel qt5-qtxml-devel
+BuildRequires: cmake qca-devel qt5-qttest-devel qt5-qtnetwork-devel qt5-qtxml-devel
 
 BuildRequires: pkgconfig(libomemo-c)
 

--- a/rpm/qxmpp.spec
+++ b/rpm/qxmpp.spec
@@ -14,8 +14,6 @@ BuildRequires: cmake qca-devel qt5-qttest-devel qt5-qtnetwork-devel qt5-qtxml-de
 
 BuildRequires: pkgconfig(libomemo-c)
 
-Requires:      pkgconfig(libomemo-c)
-
 %description
 QXmpp is a cross-platform C++ XMPP client and server library. It is written in C++ and uses Qt framework.
 


### PR DESCRIPTION
To be able to keep up with upstread omemo from the dino project, i had created v. 0.5.1 and protobuf builds on sailfish obs. This patch makes it possible to build with those.

Please see: 
https://build.sailfishos.org/project/show/home:poetaster:omemo